### PR TITLE
chore: Bump SDK to 0.45.7-reap.sdk.v0.4.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/rakyll/statik v0.1.7
-	github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20
+	github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21
 	github.com/reapchain/reapchain-core v0.34.20-reap.core.v0.1.24
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1072,8 +1072,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20 h1:kbcLcH5yuecyx2kOJUKA1GKDmyZg9yOhfv1oqd/4RCE=
-github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.20/go.mod h1:I3Wo3Cb8nnWZ0JgUctDMcZOPcNHsW5SKITEI3jBBMr4=
+github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21 h1:FV9LxAn8csWyo0zgDCz/NRW872cV8dwlxZjpouI5KPg=
+github.com/reapchain/cosmos-sdk v0.45.7-reap.sdk.v0.4.21/go.mod h1:I3Wo3Cb8nnWZ0JgUctDMcZOPcNHsW5SKITEI3jBBMr4=
 github.com/reapchain/iavl v0.19.0-reap.iavl.v0.2.15 h1:55zL7iuUaOi9Y3rk4IP808svdF9IG+iFlPLkdieUesU=
 github.com/reapchain/iavl v0.19.0-reap.iavl.v0.2.15/go.mod h1:MgF055gx3gwcShAoCUzt+um46W88iQ1BZz4GJFXzoXc=
 github.com/reapchain/reapchain-core v0.34.20-reap.core.v0.1.24 h1:L/3DMs5Q4qs0xkeovmZhZ86I1fjAgtct0C84MotjJfI=


### PR DESCRIPTION
# Pull Request: Bump SDK to 0.45.7-reap.sdk.v0.4.21

## Description
This pull request proposes bumping the SDK version to `0.45.7-reap.sdk.v0.4.21`. The update primarily involves updating the SDK dependency to the specified version.

## Changes Made
- Updated SDK dependency to version `0.45.7-reap.sdk.v0.4.21`.
 
